### PR TITLE
add support for not handling exceptions

### DIFF
--- a/srpy.py
+++ b/srpy.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     parser.add_argument("-v", "--verbose", help="Turn on verbose output, including full packet dumps in test results.  Can be specified multiple times to increase verbosity.", dest="verbose", action="count", default=0)
     parser.add_argument("-d", "--debug", help="Turn on debug logging output.", dest="debug", action="store_true", default=False)
     parser.add_argument("--nopdb", help="Don't enter pdb on crash.", dest="nopdb", action="store_true", default=False)
+    parser.add_argument("--nohandle", help="Don't handle exception on crash.", dest="no_handle", action="store_true", default=False)
     parser.add_argument("-f", "--firewall", help="Specify host firewall rules (for real/live mode only)", dest="fwconfig", action="append")
     parser.add_argument("-a", "--app", help="Specify application layer (socket-based) program to start (EXPERIMENTAL!)", dest="app", default=None)
     args = parser.parse_args()
@@ -91,7 +92,7 @@ if __name__ == '__main__':
     if args.testmode:
         if args.usercode and args.compile:
             log_info("You specified user code to run with compile flag, but I'm just doing compile.")
-        main_test(args.compile, args.scenario, args.usercode, args.dryrun, args.nopdb, args.verbose)
+        main_test(args.compile, args.scenario, args.usercode, args.dryrun, args.nopdb, args.verbose, args.no_handle)
     else:
         if sys.platform != 'win32' and os.geteuid() != 0:
             log_warn("You're running in real mode, but not as root.  "
@@ -119,4 +120,4 @@ if __name__ == '__main__':
             setup_ok = True
             barrier.wait()
             netobj = PyLLNet(devlist)
-            main_real(args.usercode, args.dryrun, netobj, args.nopdb, args.verbose)
+            main_real(args.usercode, args.dryrun, netobj, args.nopdb, args.verbose, args.no_handle)

--- a/switchyard/switchy_test.py
+++ b/switchyard/switchy_test.py
@@ -94,7 +94,7 @@ class FakePyLLNet(LLNetBase):
             pass
         self.timestamp += 1.0
 
-def run_tests(scenario_names, usercode_entry_point, no_pdb, verbose):
+def run_tests(scenario_names, usercode_entry_point, no_pdb, verbose, no_handle):
     '''
     Given a list of scenario names, set up fake network object with the
     scenario objects, and invoke the user module.
@@ -109,6 +109,13 @@ def run_tests(scenario_names, usercode_entry_point, no_pdb, verbose):
         log_info("Starting test scenario {}".format(sname))
         exc,value,tb = None,None,None
         message = '''All tests passed!'''
+        if no_handle:
+            try:
+                disable_timer()
+                usercode_entry_point(net)
+            except Shutdown:
+                return
+            return
         try:
             usercode_entry_point(net)
         except Shutdown:
@@ -202,7 +209,7 @@ If you don't want pdb, use the --nopdb flag to avoid this fate.
                 print ('{}'.format(message), file=sys.stderr)
 
 
-def main_test(compile, scenarios, usercode, dryrun, no_pdb, verbose):
+def main_test(compile, scenarios, usercode, dryrun, no_pdb, verbose, no_handle):
     '''
         Entrypoint function for either compiling or running test scenarios.
 
@@ -221,5 +228,5 @@ def main_test(compile, scenarios, usercode, dryrun, no_pdb, verbose):
         if dryrun:
             log_info("Imported your code successfully.  Exiting dry run.")
             return
-        run_tests(scenarios, usercode_entry_point, no_pdb, verbose)
+        run_tests(scenarios, usercode_entry_point, no_pdb, verbose, no_handle)
 


### PR DESCRIPTION
This adds a new command line flag, `--nohandle`, which tells switchyard not to catch exceptions in your code. This allows you to run something like `python -m pudb switchyard/srpy.py ...` to use a custom debugger, which fixes #2